### PR TITLE
Improve Presidio Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ To install a specific version, use the attribute `imageVersion`.
 
 ```sh
 helm upgrade --install presidio \
-	oci://ghcr.io/hoophq/helm-charts/presidio-chart --version v0.0.3 \
-	--set imageVersion=2.2.358
+	oci://ghcr.io/hoophq/helm-charts/presidio-chart --version v0.0.4 \
+	--set imageVersion=2.2.362
 ```
 
 See the release pages of Presidio for version information:

--- a/chart/templates/autoscaling.yaml
+++ b/chart/templates/autoscaling.yaml
@@ -1,0 +1,119 @@
+# templates/hpa.yaml
+
+{{- if .Values.analyzer.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: presidio-analyzer-hpa
+  labels:
+    app: presidio-analyzer
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: presidio-analyzer
+  minReplicas: {{ .Values.analyzer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.analyzer.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.analyzer.autoscaling.cpuAverageUtilization }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.analyzer.autoscaling.scaleUpStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.analyzer.autoscaling.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+{{- end }}
+
+---
+
+{{- if .Values.anonymizer.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: presidio-anonymizer-hpa
+  labels:
+    app: presidio-anonymizer
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: presidio-anonymizer
+  minReplicas: {{ .Values.anonymizer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.anonymizer.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.anonymizer.autoscaling.cpuAverageUtilization }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.anonymizer.autoscaling.scaleUpStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.anonymizer.autoscaling.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+{{- end }}
+
+---
+
+{{- if .Values.envoyProxy.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: presidio-envoy-proxy-hpa
+  labels:
+    app: presidio-envoy-proxy
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: presidio-envoy-proxy
+  minReplicas: {{ .Values.envoyProxy.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.envoyProxy.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.envoyProxy.autoscaling.cpuAverageUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.envoyProxy.autoscaling.memoryAverageUtilization }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.envoyProxy.autoscaling.scaleUpStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.envoyProxy.autoscaling.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,9 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: presidio-analyzer-config
+data:
+  gunicorn_config.py: |
+    {{- .Values.analyzer.gunicornConfigFile | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: presidio-anonymizer-config
+data:
+  gunicorn_config.py: |
+    {{- .Values.anonymizer.gunicornConfigFile | nindent 4 }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: presidio-analyzer
 spec:
+  {{- if not .Values.analyzer.autoscaling.enabled }}
   replicas: {{ .Values.analyzer.replicas | default 1 }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0 
   selector:
     matchLabels:
       app: presidio-analyzer
@@ -11,16 +34,46 @@ spec:
     metadata:
       labels:
         app: presidio-analyzer
+      annotations:
+        checksum/gunicorn-config: {{ .Values.analyzer.gunicornConfigFile | sha256sum }}
     spec:
       containers:
       - image: '{{ .Values.analyzer.imageRepository | default "mcr.microsoft.com/presidio-analyzer" }}:{{ .Values.analyzer.imageTag | default "latest" }}'
         name: presidio-analyzer
-        imagePullPolicy: {{ .Values.analyzer.imagePullPolicy | default "Always" }}
+        imagePullPolicy: '{{ .Values.analyzer.imagePullPolicy | default "Always" }}'
+        command: ["gunicorn", "--config", "/opt/presidio/gunicorn_config.py", "app:create_app()"]
         resources:
           {{- toYaml .Values.analyzer.resources | nindent 10 }}
         ports:
         - containerPort: 3000
           name: api
+        env:
+        - name: GUNICORN_CMD_ARGS
+          value: '--config /opt/presidio/gunicorn_config.py'
+        volumeMounts:
+        - name: presidio-config
+          mountPath: /opt/presidio/gunicorn_config.py
+          subPath: gunicorn_config.py
+          readOnly: true
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 30   # give preload_app time to load models
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          failureThreshold: 4
+      volumes:
+      - name: presidio-config
+        configMap:
+          name: presidio-analyzer-config
       {{- with .Values.analyzer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -39,7 +92,14 @@ kind: Deployment
 metadata:
   name: presidio-anonymizer
 spec:
+  {{- if not .Values.anonymizer.autoscaling.enabled }}
   replicas: {{ .Values.anonymizer.replicas | default 1 }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0 
   selector:
     matchLabels:
       app: presidio-anonymizer
@@ -47,16 +107,31 @@ spec:
     metadata:
       labels:
         app: presidio-anonymizer
+      annotations:
+        checksum/gunicorn-config: {{ .Values.anonymizer.gunicornConfigFile | sha256sum }}
     spec:
       containers:
       - image: '{{ .Values.anonymizer.imageRepository | default "mcr.microsoft.com/presidio-anonymizer" }}:{{ .Values.anonymizer.imageTag | default "latest" }}'
         name: presidio-anonymizer
         imagePullPolicy: {{ .Values.anonymizer.imagePullPolicy | default "Always" }}
+        command: ["gunicorn", "--config", "/opt/presidio/gunicorn_config.py", "app:create_app()"]
         resources:
           {{- toYaml .Values.anonymizer.resources | nindent 10 }}
         ports:
         - containerPort: 3000
           name: api
+        env:
+        - name: GUNICORN_CMD_ARGS
+          value: '--config /opt/presidio/gunicorn_config.py'
+        volumeMounts:
+        - name: presidio-config
+          mountPath: /opt/presidio/gunicorn_config.py
+          subPath: gunicorn_config.py
+          readOnly: true
+      volumes:
+      - name: presidio-config
+        configMap:
+          name: presidio-anonymizer-config
       {{- with .Values.anonymizer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -70,28 +145,3 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: presidio-analyzer
-spec:
-  selector:
-    app: presidio-analyzer
-  ports:
-    - port: 3000
-      name: api
-      protocol: TCP
-      targetPort: 3000
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: presidio-anonymizer
-spec:
-  selector:
-    app: presidio-anonymizer
-  ports:
-    - port: 3000
-      name: api
-      protocol: TCP
-      targetPort: 3000

--- a/chart/templates/envoy-proxy-config.yaml
+++ b/chart/templates/envoy-proxy-config.yaml
@@ -1,0 +1,180 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-presidio-config
+  labels:
+    app: presidio-envoy-proxy
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9901
+
+    static_resources:
+      listeners:
+        - name: presidio_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 3010
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: presidio
+                    codec_type: AUTO
+
+                    # Downstream connection management
+                    common_http_protocol_options:
+                      idle_timeout: 300s
+                      headers_with_underscores_action: REJECT_REQUEST
+
+                    access_log:
+                      - name: envoy.access_loggers.stdout
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                          log_format:
+                            text_format: "%DOWNSTREAM_REMOTE_ADDRESS% - - [%START_TIME(%d/%b/%Y:%H:%M:%S %z)%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %BYTES_SENT% \"%REQ(REFERER)%\" \"%REQ(USER-AGENT)%\" rt=%DURATION%ms urt=%RESPONSE_DURATION%ms flags=%RESPONSE_FLAGS% upstream=%UPSTREAM_HOST% cluster=%UPSTREAM_CLUSTER% content_length=%REQ(CONTENT-LENGTH)% attempts=%UPSTREAM_REQUEST_ATTEMPT_COUNT%\n"
+
+                    route_config:
+                      name: presidio_routes
+                      virtual_hosts:
+                        - name: presidio
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                prefix: "/analyze"
+                              route:
+                                cluster: presidio_analyzer
+                                timeout: 120s
+                                retry_policy:
+                                  retry_on: "reset,connect-failure"
+                                  num_retries: 1
+                                  per_try_timeout: 30s
+                            - match:
+                                prefix: "/anonymize"
+                              route:
+                                cluster: presidio_anonymizer
+                                timeout: 120s
+                                retry_policy:
+                                  retry_on: "reset,connect-failure"
+                                  num_retries: 1
+                                  per_try_timeout: 60s
+                            - match:
+                                prefix: "/health"
+                              route:
+                                cluster: presidio_analyzer
+                                timeout: 10s
+
+                    http_filters:
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      clusters:
+      - name: presidio_analyzer
+        type: STRICT_DNS
+        dns_lookup_family: V4_ONLY
+        connect_timeout: 5s
+        lb_policy: LEAST_REQUEST
+        least_request_lb_config:
+          choice_count: 2
+
+        max_requests_per_connection: 0
+
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http_protocol_options: {}
+            common_http_protocol_options:
+              idle_timeout: 60s
+
+        load_assignment:
+          cluster_name: presidio_analyzer
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: presidio-analyzer-envoy
+                        port_value: 3000
+
+        health_checks:
+          - timeout: 5s
+            interval: 10s
+            unhealthy_threshold: 3
+            healthy_threshold: 2
+            http_health_check:
+              path: "/health"
+
+        circuit_breakers:
+          thresholds:
+            - priority: DEFAULT
+              max_connections: 48
+              max_pending_requests: 50
+              max_requests: 200
+              max_retries: 4
+
+        outlier_detection:
+          consecutive_5xx: 3
+          consecutive_gateway_failure: 3
+          interval: 10s
+          base_ejection_time: 30s
+          max_ejection_percent: 50
+          success_rate_minimum_hosts: 3
+          success_rate_request_volume: 5
+      - name: presidio_anonymizer
+        type: STRICT_DNS
+        dns_lookup_family: V4_ONLY
+        connect_timeout: 5s
+        lb_policy: LEAST_REQUEST
+        least_request_lb_config:
+          choice_count: 2
+
+        max_requests_per_connection: 0
+
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http_protocol_options: {}
+            common_http_protocol_options:
+              idle_timeout: 60s
+
+        load_assignment:
+          cluster_name: presidio_anonymizer
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: presidio-anonymizer-envoy
+                        port_value: 3000
+
+        health_checks:
+          - timeout: 5s
+            interval: 10s
+            unhealthy_threshold: 3
+            healthy_threshold: 2
+            http_health_check:
+              path: "/health"
+
+        circuit_breakers:
+          thresholds:
+            - priority: DEFAULT
+              max_connections: 48
+              max_pending_requests: 50
+              max_requests: 200
+              max_retries: 4
+
+        outlier_detection:
+          consecutive_5xx: 3
+          consecutive_gateway_failure: 3
+          interval: 10s
+          base_ejection_time: 30s
+          max_ejection_percent: 50
+          success_rate_minimum_hosts: 3
+          success_rate_request_volume: 5

--- a/chart/templates/envoy-proxy.yaml
+++ b/chart/templates/envoy-proxy.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: presidio-envoy-proxy
+  labels:
+    app: presidio-envoy-proxy
+spec:
+  {{- if not .Values.envoyProxy.autoscaling.enabled }}
+  replicas: {{ .Values.envoyProxy.replicas | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: presidio-envoy-proxy
+  template:
+    metadata:
+      labels:
+        app: presidio-envoy-proxy
+      annotations:
+        checksum/envoy-config: {{ include (print $.Template.BasePath "/envoy-proxy-config.yaml") . | sha256sum }}
+    spec:
+      containers:
+      - name: envoy
+        image: '{{ .Values.envoyProxy.imageRepository | default "envoyproxy/envoy" }}:{{ .Values.envoyProxy.imageTag | default "v1.33-latest" }}'
+        imagePullPolicy: {{ .Values.envoyProxy.imagePullPolicy | default "Always" }}
+        resources:
+          {{- toYaml .Values.envoyProxy.resources | nindent 10 }}
+        ports:
+          - name: http
+            containerPort: 3010
+            protocol: TCP
+          - name: admin
+            containerPort: 9901
+            protocol: TCP  
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9901
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 9901
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        volumeMounts:
+          - name: envoy-config
+            mountPath: /etc/envoy
+            readOnly: true
+      {{- with .Values.envoyProxy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.envoyProxy.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.envoyProxy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: envoy-presidio-config

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    hoop.dev/note: 'resource deprecated and unused due to the introduction of envoy proxy'
+  name: presidio-analyzer
+spec:
+  selector:
+    app: presidio-analyzer
+  ports:
+    - port: 3000
+      name: api
+      protocol: TCP
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    hoop.dev/note: 'resource deprecated and unused due to the introduction of envoy proxy'
+  name: presidio-anonymizer
+spec:
+  selector:
+    app: presidio-anonymizer
+  ports:
+    - port: 3000
+      name: api
+      protocol: TCP
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: presidio-analyzer-envoy
+spec:
+  clusterIP: None # headless service
+  selector:
+    app: presidio-analyzer
+  ports:
+    - port: 3000
+      name: api
+      protocol: TCP
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: presidio-anonymizer-envoy
+spec:
+  clusterIP: None # headless service
+  selector:
+    app: presidio-anonymizer
+  ports:
+    - port: 3000
+      name: api
+      protocol: TCP
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: presidio-envoy-lb
+  labels:
+    app: presidio-envoy-proxy
+spec:
+  selector:
+    app: presidio-envoy-proxy
+  ports:
+    - name: http
+      port: 3010
+      targetPort: 3010
+      protocol: TCP
+    - name: admin
+      port: 9901
+      targetPort: 9901
+      protocol: TCP

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,3 @@
-# Presidio version information: https://github.com/microsoft/presidio/releases
-
 # -- Analyzer service configuration
 analyzer:
   replicas: 1
@@ -8,6 +6,7 @@ analyzer:
   # Presidio version information: https://github.com/microsoft/presidio/releases
   imageTag: latest
 
+  # Presidio WSGI HTTP Server configuration
   gunicornConfigFile: |
     bind = '0.0.0.0:3000'
     workers = 2
@@ -19,12 +18,12 @@ analyzer:
     worker_class = 'gthread'
 
   resources:
-    limits:
-      cpu: 2100m
-      memory: 2048Mi
     requests:
       cpu: 1024m
       memory: 1024Mi
+    limits:
+      cpu: 2500m
+      memory: 2048Mi
 
   # -- AutoScaling: Horizontal Pod AutoScaler
   autoscaling:
@@ -55,6 +54,7 @@ anonymizer:
   # Presidio version information: https://github.com/microsoft/presidio/releases
   imageTag: latest
 
+  # Presidio WSGI HTTP Server configuration
   gunicornConfigFile: |
     bind = '0.0.0.0:3000'
     workers = 2
@@ -66,12 +66,12 @@ anonymizer:
     worker_class = 'gthread'
 
   resources:
-    limits:
-      cpu: 2048m
-      memory: 1024Mi
     requests:
       cpu: 256m
       memory: 512Mi
+    limits:
+      cpu: 2048m
+      memory: 1024Mi
 
   # -- AutoScaling: Horizontal Pod AutoScaler
   autoscaling:
@@ -97,15 +97,15 @@ anonymizer:
 # -- Envoy Proxy
 envoyProxy:
   replicas: 1
-  image: envoyproxy/envoy
+  imageRepository: envoyproxy/envoy
   imageTag: v1.33-latest
   resources:
-    limits:
-      cpu: 500m
-      memory: 128Mi
     requests:
       cpu: 100m
       memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 128Mi
 
   # -- AutoScaling: Horizontal Pod AutoScaler
   autoscaling:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,19 +1,42 @@
 # Presidio version information: https://github.com/microsoft/presidio/releases
 
-# analyzer service configuration
+# -- Analyzer service configuration
 analyzer:
   replicas: 1
   imageRepository: mcr.microsoft.com/presidio-analyzer
   imagePullPolicy: Always
   # Presidio version information: https://github.com/microsoft/presidio/releases
   imageTag: latest
+
+  gunicornConfigFile: |
+    bind = '0.0.0.0:3000'
+    workers = 2
+    threads = 4
+    timeout = 120
+    keep_alive = 65
+    preload_app = True
+    loglevel = 'debug'
+    worker_class = 'gthread'
+
   resources:
     limits:
-      cpu: 512m
-      memory: 1024Mi
+      cpu: 2100m
+      memory: 2048Mi
     requests:
-      cpu: 256m
+      cpu: 1024m
       memory: 1024Mi
+
+  # -- AutoScaling: Horizontal Pod AutoScaler
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 6
+    # -- Target CPU utilization percentage to trigger scaling
+    cpuAverageUtilization: 70
+    # -- Seconds to wait before allowing further scale up after a scaling event
+    scaleUpStabilizationWindowSeconds: 30
+    # -- Seconds to wait before allowing further scale down after a scaling event
+    scaleDownStabilizationWindowSeconds: 120
 
   # -- Node labels for pod assignment
   nodeSelector: {}
@@ -24,20 +47,79 @@ analyzer:
   # -- Affinity settings for pod assignment
   affinity: {}
 
-# anonymizer service configuration
+# -- Anonymizer service configuration
 anonymizer:
   replicas: 1
   imageRepository: mcr.microsoft.com/presidio-anonymizer
   imagePullPolicy: Always
   # Presidio version information: https://github.com/microsoft/presidio/releases
   imageTag: latest
+
+  gunicornConfigFile: |
+    bind = '0.0.0.0:3000'
+    workers = 2
+    threads = 4
+    timeout = 120
+    keep_alive = 65
+    preload_app = True
+    loglevel = 'debug'
+    worker_class = 'gthread'
+
   resources:
     limits:
-      cpu: 512m
-      memory: 512Mi
+      cpu: 2048m
+      memory: 1024Mi
     requests:
       cpu: 256m
       memory: 512Mi
+
+  # -- AutoScaling: Horizontal Pod AutoScaler
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 4
+    # -- Target CPU utilization percentage to trigger scaling
+    cpuAverageUtilization: 70
+    # -- Seconds to wait before allowing further scale up after a scaling event
+    scaleUpStabilizationWindowSeconds: 30
+    # -- Seconds to wait before allowing further scale down after a scaling event
+    scaleDownStabilizationWindowSeconds: 120
+
+  # -- Node labels for pod assignment
+  nodeSelector: {}
+
+  # -- Toleration labels for pod assignment
+  tolerations: []
+
+  # -- Affinity settings for pod assignment
+  affinity: {}
+
+# -- Envoy Proxy
+envoyProxy:
+  replicas: 1
+  image: envoyproxy/envoy
+  imageTag: v1.33-latest
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+
+  # -- AutoScaling: Horizontal Pod AutoScaler
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    # -- Target CPU utilization percentage to trigger scaling
+    cpuAverageUtilization: 75
+    # -- Target memory utilization percentage to trigger scaling
+    memoryAverageUtilization: 80
+    # -- Seconds to wait before allowing further scale up after a scaling event
+    scaleUpStabilizationWindowSeconds: 60
+    # -- Seconds to wait before allowing further scale down after a scaling event
+    scaleDownStabilizationWindowSeconds: 180
 
   # -- Node labels for pod assignment
   nodeSelector: {}


### PR DESCRIPTION
- Add Envoy Proxy to load balance connections based on least requests policy
- Tune Gunicorn to allow more concurrent requests per instances and avoid blocking other api requests
- Add Horizontal Pod AutoScaler for all components